### PR TITLE
adding condition for datetime to be string or number

### DIFF
--- a/ios/TextChatAccPackKit/OTTextChatKit.podspec
+++ b/ios/TextChatAccPackKit/OTTextChatKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OTTextChatKit"
-  s.version          = "2.0.0-beta4"
+  s.version          = "2.0.0-beta5"
   s.summary          = "OpenTok Text Chat Accelerator Pack enables text messages between mobile or browser-based devices."
 
   s.description      = "This document describes how to use the OpenTok Text Chat Accelerator Pack for iOS. Through the exploration of the One to One Text Chat Sample Application, you will learn best practices for exchanging text messages on an iOS mobile device."

--- a/ios/TextChatAccPackKit/OTTextChatKit/OTTextMessage/OTTextMessage.m
+++ b/ios/TextChatAccPackKit/OTTextChatKit/OTTextMessage/OTTextMessage.m
@@ -85,8 +85,7 @@ static NSString * const kCustomData = @"customData";
             _senderId = dict[kSender][kSenderId];
         }
 
-
-        if (dict[kSendOn] && [dict[kSendOn] isKindOfClass:[NSString class]]) {
+        if (dict[kSendOn] && [dict[kSendOn] isKindOfClass:[NSNumber class]]) {
             _dateTime = [NSDate dateWithTimeIntervalSince1970:([dict[kSendOn] doubleValue] / 1000)];
         }
 
@@ -103,7 +102,7 @@ static NSString * const kCustomData = @"customData";
     NSMutableDictionary *json = [NSMutableDictionary dictionary];
     json[kText] = self.text;
     json[kSender] = @{kSenderAlias: self.alias, kSenderId: self.senderId};
-    json[kSendOn] = [NSString stringWithFormat:@"%@", @([self.dateTime timeIntervalSince1970] * 1000)];
+    json[kSendOn] = @([self.dateTime timeIntervalSince1970] * 1000);
     if (self.customData) {
         json[kCustomData] = self.customData;
     }


### PR DESCRIPTION
adding a condition for datetime to be string or number when receiving a new messages from the other end, this will avoid the error that crashes the app when the first message is send by the other end and datetime is a long instead of a string.